### PR TITLE
Lexer::disableStripWhitespace() has protected visibility

### DIFF
--- a/library/Phly/Mustache/Lexer.php
+++ b/library/Phly/Mustache/Lexer.php
@@ -80,7 +80,7 @@ class Lexer
      * @param  null|bool $flag Null indicates retrieving; boolean value sets
      * @return bool|Lexer
      */
-    protected function disableStripWhitespace($flag = null)
+    public function disableStripWhitespace($flag = null)
     {
         if (null === $flag) {
             return !$this->stripWhitespaceFlag;


### PR DESCRIPTION
The patch just changes the visibility of this method to public.
This reflect the intended usage [explained in the readme](https://github.com/weierophinney/phly_mustache/commit/27e90070501f5cf2422c2949fcb3a9a1ce07423c)
