### PR TITLE
Heirarchical templates with same parents use the results of the first render returning for subsequent renderings

### DIFF
--- a/tests/PhlyTest/Mustache/HierarchicalViewsTest.php
+++ b/tests/PhlyTest/Mustache/HierarchicalViewsTest.php
@@ -95,4 +95,16 @@ class HierarchicalViewsTest extends \PHPUnit_Framework_TestCase
         $test = $this->mustache->render('issue-17-nested-child-2', array());
         $this->assertRegexp('#<div class="container-fluid">\s+<div class="row-fluid">.*?<div class="span9">\s+new content#s', $test, $test);
     }
+
+    /**
+     * @group issue-25
+     */
+    public function testCanRenderCorrectTemplatesWhenExistingParentHasBeenRendered()
+    {
+        // set up existing cache
+        $this->mustache->render('issue-25-child1', array());
+
+        $test = $this->mustache->render('issue-25-child2', array());
+        $this->assertContains('<div class="span4">This is the sidebar content for child2</div>', $test);
+    }
 }

--- a/tests/PhlyTest/Mustache/templates/issue-25-child1.mustache
+++ b/tests/PhlyTest/Mustache/templates/issue-25-child1.mustache
@@ -1,0 +1,4 @@
+{{<issue-25-parent}}
+{{$sidebar}}This is the sidebar content for child1{{/sidebar}}
+{{$content}}This is the primary content for child1{{/content}}
+{{/issue-25-parent}}

--- a/tests/PhlyTest/Mustache/templates/issue-25-child2.mustache
+++ b/tests/PhlyTest/Mustache/templates/issue-25-child2.mustache
@@ -1,0 +1,4 @@
+{{<issue-25-parent}}
+{{$sidebar}}This is the sidebar content for child2{{/sidebar}}
+{{$content}}This is the primary content for child2{{/content}}
+{{/issue-25-parent}}

--- a/tests/PhlyTest/Mustache/templates/issue-25-parent.mustache
+++ b/tests/PhlyTest/Mustache/templates/issue-25-parent.mustache
@@ -1,0 +1,6 @@
+<div class="row-fluid">
+    <div class="span4">{{$sidebar}} {{/sidebar}}</div>
+    <div class="span8">
+        {{$content}} {{/content}}
+    </div>
+</div>


### PR DESCRIPTION
If the template cache is persisted between HTTP requests, or even multiple templates rendered in the same request, then if they each use the same parent template using the Heirarchical template includer, the second, third ... requests return the same response as the first template rather than the results of their own template.

e.g. child1 inherits from parent, child2 also inherits from parent, rendering child1 then child2, the second render returns child1.

This appears to be because the hierarchical template is rendered with the first child embedded, and stored in the cachedTemplates array using the parent's template name.

I will submit a pull request with the testcase in and talk about a proposed solution.
