### PR TITLE
Allow whitespace in tags

### DIFF
--- a/library/Phly/Mustache/Lexer.php
+++ b/library/Phly/Mustache/Lexer.php
@@ -178,7 +178,13 @@ class Lexer
                     $delimEndLen = strlen($this->patterns[self::DE]);
                     if (substr($tagData, -$delimEndLen) === $this->patterns[self::DE]) {
                         $tagData = substr($tagData, 0, -$delimEndLen);
-                        $tagData = trim($tagData);
+                        $tagData = trim($oldTagData = $tagData);
+
+                        if (in_array($tagData[0], str_split('%=<>!&^#$'))) {
+                            // begins with a sigil
+                            if (in_array($oldTagData[0], str_split(" \n\r\t")))
+                                throw new \Exception("Whitespace is not allowed before sigils (#, ^, $, etc.)");
+                        }
 
                         // Evaluate what kind of token we have
                         switch ($tagData[0]) {
@@ -367,9 +373,9 @@ class Lexer
                     if (preg_match('/' . $pattern . '$/', $sectionData)) {
                         // we have a match. Now, let's make sure we're balanced
                         $pattern = '/(('
-                                 . $this->implodePregQuote('\\s*', array($ds,'#',$section,$de), '/')
+                                 . $this->implodePregQuote('\\s*', array($ds . '#',$section,$de), '/')
                                  . ')|('
-                                 . $this->implodePregQuote('\\s*', array($ds,'/',$section,$de), '/')
+                                 . $this->implodePregQuote('\\s*', array($ds . '/',$section,$de), '/')
                                  . '))/';
                         preg_match_all($pattern, $sectionData, $matches);
                         $open   = 0;

--- a/tests/PhlyTest/Mustache/MustacheTest.php
+++ b/tests/PhlyTest/Mustache/MustacheTest.php
@@ -105,6 +105,24 @@ EOT;
         $this->assertEquals($expected, $test);
     }
 
+    public function testTagsCanContainWhitespace()
+    {
+        $robert = array(
+            'person' => array('name'=>'Robert')
+        );
+
+        $test = $this->mustache->render(
+            'template-with-whitespace-in-tags',
+            $robert
+        );
+        $expected =<<<EOT
+Hello, Robert
+
+EOT;
+
+        $this->assertEquals($expected, $test);
+    }
+
     public function testConditionalIsSkippedIfValueIsEmpty()
     {
         $chris = new TestAsset\ViewWithMethod;

--- a/tests/PhlyTest/Mustache/templates/template-with-whitespace-in-tags.mustache
+++ b/tests/PhlyTest/Mustache/templates/template-with-whitespace-in-tags.mustache
@@ -1,5 +1,5 @@
-Hello, {{   #   person   }}
+Hello, {{#   person   }}
 {{
 	name
 }}
-{{    /person    }}
+{{/person    }}

--- a/tests/PhlyTest/Mustache/templates/template-with-whitespace-in-tags.mustache
+++ b/tests/PhlyTest/Mustache/templates/template-with-whitespace-in-tags.mustache
@@ -1,0 +1,5 @@
+Hello, {{   #   person   }}
+{{
+	name
+}}
+{{    /person    }}


### PR DESCRIPTION
Hi, I've made a few changes to allow for whites space in mustache tags -- e.g. `{{ # section }}`. I hope this will be helpful!
- This is more consistent with other mustache engines
- Adds a test for whitespace in tags, which will fail without the
  included updates
- Trims whitespace from the beginning and end of tags
- Updates tag patterns to include whitespace in the match
- Takes the actual whitespace into account when trimming the closing
  tag off the end of a section
