### PR TITLE
Refactor exceptions

### DIFF
--- a/src/Exception/BadMethodCallException.php
+++ b/src/Exception/BadMethodCallException.php
@@ -6,11 +6,9 @@
 
 namespace Phly\Mustache\Exception;
 
-use Phly\Mustache\Exception;
-
 /**
  * Exception raised when an invalid method call is made
  */
-class BadMethodCallException extends \BadMethodCallException implements Exception
+class BadMethodCallException extends \BadMethodCallException implements ExceptionInterface
 {
 }

--- a/src/Exception/ExceptionInterface.php
+++ b/src/Exception/ExceptionInterface.php
@@ -4,11 +4,11 @@
  * @license    http://www.opensource.org/licenses/bsd-license.php New BSD License
  */
 
-namespace Phly\Mustache;
+namespace Phly\Mustache\Exception;
 
 /**
- * Base exception interface
+ * Marker interface for package-specific exceptions.
  */
-interface Exception
+interface ExceptionInterface
 {
 }

--- a/src/Exception/InvalidDelimiterException.php
+++ b/src/Exception/InvalidDelimiterException.php
@@ -6,11 +6,11 @@
 
 namespace Phly\Mustache\Exception;
 
-use Phly\Mustache\Exception;
+use DomainException;
 
 /**
  * Exception raised when a delimiter tag is malformed.
  */
-class InvalidDelimiterException extends \Exception implements Exception
+class InvalidDelimiterException extends DomainException implements ExceptionInterface
 {
 }

--- a/src/Exception/InvalidEscaperException.php
+++ b/src/Exception/InvalidEscaperException.php
@@ -6,12 +6,11 @@
 
 namespace Phly\Mustache\Exception;
 
-use Phly\Mustache\Exception;
+use InvalidArgumentException;
 
 /**
- * Exception raised when an invalid callback is registered for escaping
- * variables
+ * Exception raised when an invalid callback is registered for escaping variables.
  */
-class InvalidEscaperException extends \Exception implements Exception
+class InvalidEscaperException extends InvalidArgumentException implements ExceptionInterface
 {
 }

--- a/src/Exception/InvalidPartialsException.php
+++ b/src/Exception/InvalidPartialsException.php
@@ -6,12 +6,11 @@
 
 namespace Phly\Mustache\Exception;
 
-use Phly\Mustache\Exception;
+use InvalidArgumentException;
 
 /**
- * Exception raised when an invalid argument is passed describing available
- * partials
+ * Exception raised when an invalid argument is passed describing available partials.
  */
-class InvalidPartialsException extends \Exception implements Exception
+class InvalidPartialsException extends InvalidArgumentException implements ExceptionInterface
 {
 }

--- a/src/Exception/InvalidPragmaNameException.php
+++ b/src/Exception/InvalidPragmaNameException.php
@@ -6,11 +6,11 @@
 
 namespace Phly\Mustache\Exception;
 
-use Phly\Mustache\Exception;
+use DomainException;
 
 /**
- * Exception raised when the name provided in a pragma tag is malformed
+ * Exception raised when the name provided in a pragma tag is malformed.
  */
-class InvalidPragmaNameException extends \Exception implements Exception
+class InvalidPragmaNameException extends DomainException implements ExceptionInterface
 {
 }

--- a/src/Exception/InvalidStateException.php
+++ b/src/Exception/InvalidStateException.php
@@ -6,11 +6,11 @@
 
 namespace Phly\Mustache\Exception;
 
-use Phly\Mustache\Exception;
+use DomainException;
 
 /**
- * Exception raised when an invalid/unknown state is reached in the lexer
+ * Exception raised when an invalid/unknown state is reached in the lexer.
  */
-class InvalidStateException extends \Exception implements Exception
+class InvalidStateException extends DomainException implements ExceptionInterface
 {
 }

--- a/src/Exception/InvalidTemplateException.php
+++ b/src/Exception/InvalidTemplateException.php
@@ -6,11 +6,11 @@
 
 namespace Phly\Mustache\Exception;
 
-use Phly\Mustache\Exception;
+use InvalidArgumentException;
 
 /**
- * Exception raised when the template provided to the lexer is not a string
+ * Exception raised when the template provided to the lexer is not a string.
  */
-class InvalidTemplateException extends \Exception implements Exception
+class InvalidTemplateException extends InvalidTemplateException implements ExceptionInterface
 {
 }

--- a/src/Exception/InvalidTemplatePathException.php
+++ b/src/Exception/InvalidTemplatePathException.php
@@ -6,11 +6,11 @@
 
 namespace Phly\Mustache\Exception;
 
-use Phly\Mustache\Exception;
+use InvalidArgumentException;
 
 /**
- * Exception raised when an invalid template path is provided
+ * Exception raised when an invalid template path is provided.
  */
-class InvalidTemplatePathException extends \Exception implements Exception
+class InvalidTemplatePathException extends InvalidArgumentException implements ExceptionInterface
 {
 }

--- a/src/Exception/InvalidTokensException.php
+++ b/src/Exception/InvalidTokensException.php
@@ -6,11 +6,11 @@
 
 namespace Phly\Mustache\Exception;
 
-use Phly\Mustache\Exception;
+use RuntimeException;
 
 /**
- * Exception raised when we don't have tokens
+ * Exception raised when we don't have tokens.
  */
-class InvalidTokensException extends \Exception implements Exception
+class InvalidTokensException extends RuntimeException implements ExceptionInterface
 {
 }

--- a/src/Exception/InvalidVariableNameException.php
+++ b/src/Exception/InvalidVariableNameException.php
@@ -6,12 +6,11 @@
 
 namespace Phly\Mustache\Exception;
 
-use Phly\Mustache\Exception;
+use DomainException;
 
 /**
- * Exception raised when a malformed variable name is encountered in a template
- * by the lexer
+ * Exception raised when a malformed variable name is encountered in a template by the lexer.
  */
-class InvalidVariableNameException extends \Exception implements Exception
+class InvalidVariableNameException extends DomainException implements ExceptionInterface
 {
 }

--- a/src/Exception/TemplateNotFoundException.php
+++ b/src/Exception/TemplateNotFoundException.php
@@ -6,11 +6,11 @@
 
 namespace Phly\Mustache\Exception;
 
-use Phly\Mustache\Exception;
+use RuntimeException;
 
 /**
- * Exception raised when a matching template file may not be found
+ * Exception raised when a matching template file may not be found.
  */
-class TemplateNotFoundException extends \Exception implements Exception
+class TemplateNotFoundException extends RuntimeException implements ExceptionInterface
 {
 }

--- a/src/Exception/UnbalancedSectionException.php
+++ b/src/Exception/UnbalancedSectionException.php
@@ -6,11 +6,11 @@
 
 namespace Phly\Mustache\Exception;
 
-use Phly\Mustache\Exception;
+use DomainException;
 
 /**
- * Exception raised when an unclosed section is encountered by the lexer
+ * Exception raised when an unclosed section is encountered by the lexer.
  */
-class UnbalancedSectionException extends \Exception implements Exception
+class UnbalancedSectionException extends DomainException implements ExceptionInterface
 {
 }

--- a/src/Exception/UnbalancedTagException.php
+++ b/src/Exception/UnbalancedTagException.php
@@ -6,11 +6,11 @@
 
 namespace Phly\Mustache\Exception;
 
-use Phly\Mustache\Exception;
+use DomainException;
 
 /**
- * Exception raised when an unclosed tag is encountered by the lexer
+ * Exception raised when an unclosed tag is encountered by the lexer.
  */
-class UnbalancedTagException extends \Exception implements Exception
+class UnbalancedTagException extends DomainException implements ExceptionInterface
 {
 }

--- a/src/Exception/UnregisteredPragmaException.php
+++ b/src/Exception/UnregisteredPragmaException.php
@@ -6,12 +6,12 @@
 
 namespace Phly\Mustache\Exception;
 
-use Phly\Mustache\Exception;
+use RuntimeException;
 
 /**
  * Exception raised when the renderer encounters a pragma for which a handler
- * has not yet been registered
+ * has not yet been registered.
  */
-class UnregisteredPragmaException extends \Exception implements Exception
+class UnregisteredPragmaException extends RuntimeException implements ExceptionInterface
 {
 }


### PR DESCRIPTION
- Moved `Phly\Mustache\Exception` interface to `Phly\Mustache\Exception\ExceptionInterface`.
- Updated all extensions to reflect the above.
- Base all exceptions on more specific SPL exceptions instead of global exception class.