### PR TITLE
More Pragma improvements

### DIFF
--- a/src/Pragma/ImplicitIterator.php
+++ b/src/Pragma/ImplicitIterator.php
@@ -67,13 +67,12 @@ class ImplicitIterator implements PragmaInterface
      * Otherwise, it will output the view, escaping it unless the token
      * indicates a raw value.
      *
-     * @param  int $token
-     * @param  mixed $data
+     * @param  array $tokenStruct
      * @param  mixed $view
      * @param  array $options
      * @return mixed
      */
-    public function render($token, $data, $view, array $options, Mustache $mustache)
+    public function render(array $tokenStruct, $view, array $options, Mustache $mustache)
     {
         // If we don't have a scalar view, implicit iteration isn't possible
         if (! is_scalar($view)) {
@@ -82,7 +81,7 @@ class ImplicitIterator implements PragmaInterface
 
         // Do we escape?
         $escape = true;
-        switch ($token) {
+        switch ($tokenStruct[0]) {
             case Lexer::TOKEN_VARIABLE:
                 // Yes
                 break;
@@ -97,7 +96,7 @@ class ImplicitIterator implements PragmaInterface
 
         // Get the iterator option, and compare it to the token we received
         $iterator = isset($options['iterator']) ? $options['iterator'] : '.';
-        if ($iterator !== $data) {
+        if ($iterator !== $tokenStruct[1]) {
             return;
         }
 

--- a/src/Pragma/PragmaInterface.php
+++ b/src/Pragma/PragmaInterface.php
@@ -63,12 +63,16 @@ interface PragmaInterface
      *
      * Returning an empty value returns control to the renderer.
      *
-     * @param  int $token
-     * @param  mixed $data
+     * $tokenStruct is an array consisting minimally of:
+     *
+     * - 0: int token (from Lexer::TOKEN_* constants)
+     * - 1: mixed data (data associated with the token)
+     *
+     * @param  array $tokenStruct
      * @param  mixed $view
      * @param  array $options
      * @param  Mustache $mustache Mustache instance handling rendering.
      * @return mixed
      */
-    public function render($token, $data, $view, array $options, Mustache $mustache);
+    public function render(array $tokenStruct, $view, array $options, Mustache $mustache);
 }

--- a/src/Pragma/SubViews.php
+++ b/src/Pragma/SubViews.php
@@ -106,16 +106,15 @@ class SubViews implements PragmaInterface
      *
      * Otherwise, it will render the template and view in the SubView provided.
      *
-     * @param  int $token
-     * @param  mixed $data
+     * @param  array $tokenStruct
      * @param  mixed $view
      * @param  array $options
      * @param  Mustache $mustache
      * @return mixed
      */
-    public function render($token, $data, $view, array $options, Mustache $mustache)
+    public function render(array $tokenStruct, $view, array $options, Mustache $mustache)
     {
-        $subView = $this->getValue($data, $view);
+        $subView = $this->getValue($tokenStruct[1], $view);
 
         // If the view value is not a SubView, we cannot handle it here
         if (! $subView instanceof SubView) {

--- a/test/Pragma/ImplicitIteratorTest.php
+++ b/test/Pragma/ImplicitIteratorTest.php
@@ -61,8 +61,7 @@ class ImplicitIteratorTest extends TestCase
     {
         $mustache = new Mustache();
         $result   = $this->pragma->render(
-            Lexer::TOKEN_VARIABLE,
-            '.',
+            [Lexer::TOKEN_VARIABLE, '.'],
             '<b>foo</b>',
             [],
             $mustache
@@ -75,8 +74,7 @@ class ImplicitIteratorTest extends TestCase
     {
         $mustache = new Mustache();
         $result   = $this->pragma->render(
-            Lexer::TOKEN_VARIABLE_RAW,
-            '.',
+            [Lexer::TOKEN_VARIABLE_RAW, '.'],
             '<b>foo</b>',
             [],
             $mustache
@@ -92,8 +90,7 @@ class ImplicitIteratorTest extends TestCase
     {
         $mustache = new Mustache();
         $this->assertNull($this->pragma->render(
-            $token,
-            '.',
+            [$token, '.'],
             '<b>foo</b>',
             [],
             $mustache
@@ -120,8 +117,7 @@ class ImplicitIteratorTest extends TestCase
     {
         $mustache = new Mustache();
         $this->assertNull($this->pragma->render(
-            $token,
-            '.',
+            [$token, '.'],
             $view,
             [],
             $mustache
@@ -132,8 +128,7 @@ class ImplicitIteratorTest extends TestCase
     {
         $mustache = new Mustache();
         $result   = $this->pragma->render(
-            Lexer::TOKEN_VARIABLE,
-            'foo',
+            [Lexer::TOKEN_VARIABLE, 'foo'],
             '<b>foo</b>',
             ['iterator' => 'foo'],
             $mustache
@@ -146,8 +141,7 @@ class ImplicitIteratorTest extends TestCase
     {
         $mustache = new Mustache();
         $this->assertNull($this->pragma->render(
-            Lexer::TOKEN_VARIABLE,
-            '.',
+            [Lexer::TOKEN_VARIABLE, '.'],
             '<b>foo</b>',
             ['iterator' => 'foo'],
             $mustache
@@ -158,8 +152,7 @@ class ImplicitIteratorTest extends TestCase
     {
         $mustache = new Mustache();
         $this->assertNull($this->pragma->render(
-            Lexer::TOKEN_VARIABLE,
-            'foo',
+            [Lexer::TOKEN_VARIABLE, 'foo'],
             '<b>foo</b>',
             [],
             $mustache


### PR DESCRIPTION
This patch builds on #35, and makes the following additional changes:

- `PragmaInterface::parse()` is only called now if the specific pragma is in scope. This means that it must have been declared previously in the template or a section's parent. This is necessary to prevent pragmas making changes to tokens when the pragma has not been declared in the template.
- The `Renderer` now passes the full token to `PragmaInterface::render()`, and not the token type + token data as separate arguments. This is done to keep the semantic of a token being type + data, but also to allow for optional data to be present in other members of the token struct.