### PR TITLE
Use zend-escaper

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -90,9 +90,9 @@ Branch: feature/resolvers
 ## Escaping [#37]
 
 - [X] Use `Zend\Escaper` by default.
-- [ ] Modify `PragmaInterface::render`
+- [X] Modify `PragmaInterface::render` [#40]
   It needs to send the full token struct!
-- [ ] Create a pragma for handling contextual escaping (CSS, JS, URLs)
+- [X] Create a pragma for handling contextual escaping (CSS, JS, URLs)
 
 ## Visibility
 

--- a/TODO.md
+++ b/TODO.md
@@ -89,7 +89,9 @@ Branch: feature/resolvers
 
 ## Escaping [#37]
 
-- [ ] Use `Zend\Escaper` by default.
+- [X] Use `Zend\Escaper` by default.
+- [ ] Modify `PragmaInterface::render`
+  It needs to send the full token struct!
 - [ ] Create a pragma for handling contextual escaping (CSS, JS, URLs)
 
 ## Visibility

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     ],
     "require": {
         "php": ">=5.5",
-        "zendframework/zend-stdlib": "^2.6"
+        "zendframework/zend-stdlib": "^2.6",
+        "zendframework/zend-escaper": "^2.5"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.7",

--- a/src/Mustache.php
+++ b/src/Mustache.php
@@ -92,7 +92,6 @@ class Mustache
     public function setRenderer(Renderer $renderer)
     {
         $this->renderer = $renderer;
-        $this->renderer->setManager($this);
         return $this;
     }
 
@@ -104,7 +103,7 @@ class Mustache
     public function getRenderer()
     {
         if (null === $this->renderer) {
-            $this->setRenderer(new Renderer());
+            $this->setRenderer(new Renderer($this));
         }
         return $this->renderer;
     }

--- a/src/Pragma/ContextualEscape.php
+++ b/src/Pragma/ContextualEscape.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * @copyright  Copyright (c) 2010-2015 Matthew Weier O'Phinney <matthew@weierophinney.net>
+ * @license    http://www.opensource.org/licenses/bsd-license.php New BSD License
+ */
+
+namespace Phly\Mustache\Pragma;
+
+use Phly\Mustache\Lexer;
+use Phly\Mustache\Mustache;
+
+/**
+ * CONTEXTUAL-ESCAPE pragma
+ *
+ * When enabled, allows selecting an alternate escaping mechanism when rendering
+ * a variable. Escapers are selected by piping the type: `varname|escaper`. Valid
+ * escaping types include:
+ *
+ * - html (the default; does not need to be specified)
+ * - attr (for escaping HTML attribute values)
+ * - js (for escaping JavaScript)
+ * - css (for escaping CSS)
+ * - url (for escaping URLs)
+ *
+ * Enable the pragma as you would any other:
+ *
+ * <code>
+ * {{%CONTEXTUAL-ESCAPE}}
+ * <html>
+ * <head>
+ *    <script>{{scripts|js}}</script>
+ *    <style>{{styles|css}}</script>
+ * </head>
+ * <body>
+ *     <article class="{{article_class|attr}}">
+ *         <a href="{{article_url|url}}">link</a>
+ *     </article>
+ * </body>
+ * </html>
+ * </code>
+ */
+class ContextualEscape implements PragmaInterface
+{
+    use PragmaNameAndTokensTrait;
+
+    /**
+     * Pragma name
+     *
+     * @var string
+     */
+    private $name = 'CONTEXTUAL-ESCAPE';
+
+    /**
+     * Tokens handled by this pragma
+     * @var array
+     */
+    private $tokensHandled = [
+        Lexer::TOKEN_VARIABLE,
+    ];
+
+    /**
+     * @var string[] Valid escaping contexts.
+     */
+    private $validContexts = [
+        'html',
+        'attr',
+        'js',
+        'css',
+        'url',
+    ];
+
+    /**
+     * Escape a variable.
+     *
+     * If the variable does not contain piping, or the context specified is not
+     * understood, returns the struct without changes.
+     *
+     * Otherwise, changes the data to be the value prior to the pipe, and puts
+     * the context into the third element of the struct before returning it.
+     *
+     * @param array $tokenStruct
+     * @return array
+     */
+    public function parse(array $tokenStruct)
+    {
+        if (! $tokenStruct[0] === Lexer::TOKEN_VARIABLE) {
+            return $tokenStruct;
+        }
+
+        $data = $tokenStruct[1];
+        if (! preg_match('/^(?P<varname>[^|]+)\|(?P<context>html|attr|js|css|url)$/', $data, $matches)) {
+            return $tokenStruct;
+        }
+
+        return [
+            $tokenStruct[0],
+            $matches['varname'],
+            $matches['context'],
+        ];
+    }
+
+    /**
+     * Render a given token.
+     *
+     * If the token is not a variable, does not contain contextual
+     * information, returns null.
+     *
+     * If the view is scalar, escapes it using the context.
+     *
+     * If the view is not scalar, checks for the value in the view; if not
+     * present, returns null; otherwise, escapes the view value.
+     *
+     * @param  array $tokenStruct
+     * @param  mixed $view
+     * @param  array $options
+     * @param  Mustache $mustache Mustache instance handling rendering.
+     * @return mixed
+     */
+    public function render(array $tokenStruct, $view, array $options, Mustache $mustache)
+    {
+        if ($tokenStruct[0] !== Lexer::TOKEN_VARIABLE) {
+            return null;
+        }
+
+        if (! isset($tokenStruct[2])
+            || ! in_array($tokenStruct[2], $this->validContexts, true)
+        ) {
+            return null;
+        }
+
+        if (is_scalar($view)) {
+            return $mustache->getRenderer()->escape($view, $tokenStruct[2]);
+        }
+
+        if (is_array($view) && isset($view[$tokenStruct[1]])) {
+            $value = $view[$tokenStruct[1]];
+        } elseif (is_object($view) && isset($view->{$tokenStruct[1]})) {
+            $value = $view->{$tokenStruct[1]};
+        } elseif (is_object($view) && method_exists($view, $tokenStruct[1])) {
+            $value = $view->{$tokenStruct[1]}();
+        } else {
+            return null;
+        }
+
+        if (is_callable($value)) {
+            $value = $value();
+        }
+
+        return $mustache->getRenderer()->escape($value, $tokenStruct[2]);
+    }
+}

--- a/test/MustacheTest.php
+++ b/test/MustacheTest.php
@@ -133,7 +133,7 @@ EOT;
             $view
         );
         $expected =<<<EOT
-Joe's shopping card:
+Joe&#039;s shopping card:
 <ul>
     <li>bananas</li>
     <li>apples</li>
@@ -154,7 +154,7 @@ EOT;
             $view
         );
         $expected =<<<EOT
-Joe's shopping card:
+Joe&#039;s shopping card:
 <ul>
     <li>bananas</li>
     <li>apples</li>

--- a/test/Pragma/ContextualEscapeTest.php
+++ b/test/Pragma/ContextualEscapeTest.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * @copyright  Copyright (c) 2010-2015 Matthew Weier O'Phinney <matthew@weierophinney.net>
+ * @license    http://www.opensource.org/licenses/bsd-license.php New BSD License
+ */
+
+namespace PhlyTest\Mustache\Pragma;
+
+use Phly\Mustache\Lexer;
+use Phly\Mustache\Mustache;
+use Phly\Mustache\Pragma;
+use Phly\Mustache\Renderer;
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Escaper\Escaper;
+
+class ImplicitIteratorTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->escaper = new Escaper();
+
+        $this->renderer = new Renderer();
+        $this->renderer->setEscaper($this->escaper);
+
+        $this->mustache = $this->prophesize(Mustache::class);
+
+        $this->pragma = new Pragma\ContextualEscape;
+    }
+
+    public function testProvidesPragmaName()
+    {
+        $this->assertEquals('CONTEXTUAL-ESCAPE', $this->pragma->getName());
+    }
+
+    public function validTokens()
+    {
+        return [
+            'variable'     => [Lexer::TOKEN_VARIABLE],
+        ];
+    }
+
+    /**
+     * @dataProvider validTokens
+     */
+    public function testHandlesVariables($token)
+    {
+        $this->assertTrue($this->pragma->handlesToken($token));
+    }
+
+    public function invalidTokens()
+    {
+        return [
+            'TOKEN_CONTENT'        => [Lexer::TOKEN_CONTENT],
+            'TOKEN_COMMENT'        => [Lexer::TOKEN_COMMENT],
+            'TOKEN_SECTION'        => [Lexer::TOKEN_SECTION],
+            'TOKEN_SECTION_INVERT' => [Lexer::TOKEN_SECTION_INVERT],
+            'TOKEN_PARTIAL'        => [Lexer::TOKEN_PARTIAL],
+            'TOKEN_DELIM_SET'      => [Lexer::TOKEN_DELIM_SET],
+            'TOKEN_PRAGMA'         => [Lexer::TOKEN_PRAGMA],
+            'TOKEN_PLACEHOLDER'    => [Lexer::TOKEN_PLACEHOLDER],
+            'TOKEN_CHILD'          => [Lexer::TOKEN_CHILD],
+            'TOKEN_VARIABLE_RAW'   => [Lexer::TOKEN_VARIABLE_RAW],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidTokens
+     */
+    public function testDoesNotHandleNonVariableTokens($token)
+    {
+        $this->assertFalse($this->pragma->handlesToken($token));
+    }
+
+    /**
+     * @dataProvider invalidTokens
+     */
+    public function testParseReturnsTokenUnchangedForTokensItDoesNotHandle($token)
+    {
+        $struct = [$token, 'foo'];
+        $this->assertSame($this->pragma->parse($struct));
+    }
+
+    public function testParseLeavesTokenUnchangedIfItDoesNotHaveContextualInfo()
+    {
+        $struct = [
+            Lexer::TOKEN_VARIABLE,
+            'foo'
+        ];
+        $result = $this->pragma->parse($struct);
+        $this->assertSame($struct, $result);
+    }
+
+    public function testParseReturnsSameTokenType()
+    {
+        $struct = [
+            Lexer::TOKEN_VARIABLE,
+            'foo|css'
+        ];
+        $result = $this->pragma->parse($struct);
+        $this->assertNotSame($struct, $result);
+        $this->assertInternalType('array', $result);
+        $this->assertSame(Lexer::TOKEN_VARIABLE, $result[0]);
+        return $result;
+    }
+
+    /**
+     * @depends testParseReturnsSameTokenType
+     */
+    public function testParseStripsContextualInfoFromTokenData($token)
+    {
+        $this->assertEquals('foo', $token[1]);
+        return $token;
+    }
+
+    /**
+     * @depends testParseStripsContextualInfoFromTokenData
+     */
+    public function testParseAddsContextualDataAsThirdElementOfToken($token)
+    {
+        $this->assertEquals('css', $token[2]);
+    }
+
+    /**
+     * @dataProvider invalidTokens
+     */
+    public function testRenderReturnsNullForTokensItDoesNotHandle($token)
+    {
+        $struct = [
+            $token,
+            'foo',
+            'css',
+        ];
+
+        $this->assertNull($this->pragma->render($token, ['foo' => 'value'], [], $this->mustache->reveal()));
+    }
+
+    public function testRenderReturnsNullIfTokenHasNoContextualInfo()
+    {
+        $struct = [
+            Lexer::TOKEN_VARIABLE,
+            'foo',
+        ];
+
+        $this->assertNull($this->pragma->render($token, ['foo' => 'value'], [], $this->mustache));
+    }
+
+    public function escapeContexts()
+    {
+        return [
+            'html' => ['html', 'escapeHtml'],
+            'attr' => ['attr', 'escapeHtmlAttr'],
+            'js'   => ['js', 'escapeJs'],
+            'css'  => ['css', 'escapeCss'],
+            'url'  => ['url', 'escapeUrl'],
+        ];
+    }
+
+    /**
+     * @dataProvider escapeContexts
+     */
+    public function testRenderEscapesUsingContextualInfo($context, $escapeMethod)
+    {
+        $this->mustache->getRenderer()->willReturn($this->renderer);
+
+        $struct = [
+            Lexer::TOKEN_VARIABLE,
+            'foo',
+            $context
+        ];
+        $view = ['foo' => 'What\'s up, Doctor & Nurse?'];
+
+        $expected = $this->escaper->{$escapeMethod}($view['foo']);
+
+        $this->assertNull($this->pragma->render($token, $view, [], $this->mustache->reveal()));
+    }
+}


### PR DESCRIPTION
The escaping functionality included with phly-mustache is rudimentary and mostly gets the job done; its primary saving grace is that it's pluggable, allowing adding something more robust.

This patch does two things:

- switches to using zend-escaper for all escaping.
- provides a new pragma, `CONTEXTUAL-ESCAPE`, for selecting which escape type should be used for the current variable.

Due to the latter, variables may now opt-in to escaping for:

- html (default; no need to specify)
- HTML attributes
- javascript
- css
- URLs

This allows using the following syntax in order to select an escaping mechanism:

```html
{{script|js}}
{{style|css}}
{{href|url}}
```